### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Testien ajaminen /app/ kansiosta:
 `./gradlew test`
 
 Sovelluksen käyttö on yksinkertaista. Alkunäkymässä sovellus listaa siihen syötetyt kirjat. Voit lisätä kirjan painamalla lisää kirja, syöttämällä kirjan tiedot lomakkeisiin, ja painamalla Lisää.
+

--- a/app/src/main/java/logic/Book.java
+++ b/app/src/main/java/logic/Book.java
@@ -84,7 +84,7 @@ public class Book implements Bookmark {
 
     @Override
     public String toString() {
-        return this.title + " ," + this.author + " ,sivumäärä: " + this.pageCount + ", nykyinen sivu: " + this.currentPage;
+        return this.title + " ," + this.author + ", sivumäärä: " + this.pageCount + ", nykyinen sivu: " + this.currentPage;
 
     }
 


### PR DESCRIPTION
Fix typo in Book method toString(), where there was unnecessary space between a word and comma, and no space after that comma.